### PR TITLE
Support for BigInt field types

### DIFF
--- a/src/autoIncrement.ts
+++ b/src/autoIncrement.ts
@@ -39,7 +39,7 @@ export function AutoIncrementSimple(
       throw new Error(`Field "${field.field}" does not exists on the Schema!`);
     }
     // check if the field is an number
-    if (!(schemaField instanceof mongoose.Schema.Types.Number || schemaField instanceof mongoose.Schema.Types.BigInt)) {
+    if (schemaField.instance !== 'Number' && schemaField.instance !== 'BigInt') {
       throw new Error(`Field "${field.field}" is not a Number or BigInt!`);
     }
 
@@ -93,7 +93,8 @@ export function AutoIncrementID(schema: mongoose.Schema<any>, options: AutoIncre
 
   // check if the field is an number
   const schemaField = schema.path(opt.field);
-  if (!(schemaField instanceof mongoose.Schema.Types.Number || schemaField instanceof mongoose.Schema.Types.BigInt)) {
+
+  if (schemaField.instance !== 'Number' && schemaField.instance !== 'BigInt') {
     throw new Error(`Field "${opt.field}" is not a Number or BigInt!`);
   }
 

--- a/src/autoIncrement.ts
+++ b/src/autoIncrement.ts
@@ -39,8 +39,8 @@ export function AutoIncrementSimple(
       throw new Error(`Field "${field.field}" does not exists on the Schema!`);
     }
     // check if the field is an number
-    if (!(schemaField instanceof mongoose.Schema.Types.Number)) {
-      throw new Error(`Field "${field.field}" is not an SchemaNumber!`);
+    if (!(schemaField instanceof mongoose.Schema.Types.Number || schemaField instanceof mongoose.Schema.Types.BigInt)) {
+      throw new Error(`Field "${field.field}" is not a Number or BigInt!`);
     }
 
     if (isNullOrUndefined(field.incrementBy)) {
@@ -92,8 +92,9 @@ export function AutoIncrementID(schema: mongoose.Schema<any>, options: AutoIncre
   };
 
   // check if the field is an number
-  if (!(schema.path(opt.field) instanceof mongoose.Schema.Types.Number)) {
-    throw new Error(`Field "${opt.field}" is not an SchemaNumber!`);
+  const schemaField = schema.path(opt.field);
+  if (!(schemaField instanceof mongoose.Schema.Types.Number || schemaField instanceof mongoose.Schema.Types.BigInt)) {
+    throw new Error(`Field "${opt.field}" is not a Number or BigInt!`);
   }
 
   let model: mongoose.Model<AutoIncrementIDTrackerSpec>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,5 +58,5 @@ export interface AutoIncrementIDTrackerSpec {
   /** The field in the schema */
   field: string;
   /** Current Tracker count */
-  count: number;
+  count: bigint;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface AutoIncrementOptionsSimple {
    * How much to increment the field by
    * @default 1
    */
-  incrementBy?: number;
+  incrementBy?: number | bigint;
 }
 
 export type AutoIncrementSimplePluginOptions = AutoIncrementOptionsSimple | AutoIncrementOptionsSimple[];
@@ -17,7 +17,7 @@ export interface AutoIncrementIDOptions {
    * How much to increment the field by
    * @default 1
    */
-  incrementBy?: number;
+  incrementBy?: number | bigint;
   /**
    * Set the field to increment
    * -> Only use this if it is not "_id"
@@ -38,7 +38,7 @@ export interface AutoIncrementIDOptions {
    * the count should start at
    * @default 0
    */
-  startAt?: number;
+  startAt?: number | bigint;
   /**
    * Overwrite what to use for the `modelName` property in the tracker document
    * This can be overwritten when wanting to use a single tracker for multiple models

--- a/test/__snapshots__/basic.test.ts.snap
+++ b/test/__snapshots__/basic.test.ts.snap
@@ -6,4 +6,4 @@ exports[`Basic Suite AutoIncrementID should throw a error if "overwriteModelName
 
 exports[`Errors should Error if the schema path does not exist 1`] = `"Field \\"SomeNonExistingField\\" does not exists on the Schema!"`;
 
-exports[`Errors should Error if the schema path is not an number 1`] = `"Field \\"nonNumberField\\" is not an SchemaNumber!"`;
+exports[`Errors should Error if the schema path is not an number 1`] = `"Field \\"nonNumberField\\" is not a Number or BigInt!"`;

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -5,12 +5,12 @@ import { AutoIncrementID, AutoIncrementSimple } from '../src/autoIncrement';
 
 describe('Basic Suite', () => {
   describe('AutoIncrementSimple', () => {
-    it('Basic Function Mongoose', async () => {
+    it('Basic Function Mongoose (Number)', async () => {
       const schema = new mongoose.Schema({
         somefield: Number,
       });
       schema.plugin(AutoIncrementSimple, [{ field: 'somefield' }]);
-      const model = mongoose.model('AutoIncrementSimple-SomeModel', schema);
+      const model = mongoose.model('AutoIncrementSimple-SomeModel-Number', schema);
 
       const doc = await model.create({ somefield: 10 });
       expect(doc.somefield).toBe(10);
@@ -19,9 +19,9 @@ describe('Basic Suite', () => {
       expect(doc.somefield).toBe(11);
     });
 
-    it('Basic Function Typegoose', async () => {
+    it('Basic Function Typegoose (Number)', async () => {
       @plugin(AutoIncrementSimple, [{ field: 'someIncrementedField' }])
-      @modelOptions({ options: { customName: 'AutoIncrementSimple-SomeClass' } })
+      @modelOptions({ options: { customName: 'AutoIncrementSimple-SomeClass-Number' } })
       class SomeClass {
         @prop({ required: true })
         public someIncrementedField: number;
@@ -34,6 +34,37 @@ describe('Basic Suite', () => {
 
       await doc.save();
       expect(doc.someIncrementedField).toBe(11);
+    });
+
+    it('Basic Function Mongoose (BigInt)', async () => {
+      const schema = new mongoose.Schema({
+        somefield: BigInt,
+      });
+      schema.plugin(AutoIncrementSimple, [{ field: 'somefield' }]);
+      const model = mongoose.model('AutoIncrementSimple-SomeModel-BigInt', schema);
+
+      const doc = await model.create({ somefield: 10n });
+      expect(doc.somefield).toBe(10n);
+
+      await doc.save();
+      expect(doc.somefield).toBe(11n);
+    });
+
+    it('Basic Function Typegoose (BigInt)', async () => {
+      @plugin(AutoIncrementSimple, [{ field: 'someIncrementedField' }])
+      @modelOptions({ options: { customName: 'AutoIncrementSimple-SomeClass-BigInt' } })
+      class SomeClass {
+        @prop({ required: true })
+        public someIncrementedField: bigint;
+      }
+
+      const SomeModel = getModelForClass(SomeClass);
+
+      const doc = await SomeModel.create({ someIncrementedField: 10n });
+      expect(doc.someIncrementedField).toBe(10n);
+
+      await doc.save();
+      expect(doc.someIncrementedField).toBe(11n);
     });
   });
 
@@ -83,7 +114,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeModel-Number' }).orFail();
-      expect(foundTracker.count).toEqual(2);
+      expect(foundTracker.count).toEqual(2n);
     });
 
     it('Basic Function Typegoose (Number)', async () => {
@@ -136,7 +167,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeClass-Number' }).orFail();
-      expect(foundTracker.count).toEqual(2);
+      expect(foundTracker.count).toEqual(2n);
     });
 
     it('Basic Function Mongoose (BigInt)', async () => {
@@ -184,7 +215,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeModel-BigInt' }).orFail();
-      expect(foundTracker.count).toEqual(2);
+      expect(foundTracker.count).toEqual(2n);
     });
 
     it('Basic Function Typegoose (BigInt)', async () => {
@@ -237,7 +268,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeClass-BigInt' }).orFail();
-      expect(foundTracker.count).toEqual(2);
+      expect(foundTracker.count).toEqual(2n);
     });
 
     it('Basic Function Mongoose With startAt', async () => {
@@ -364,7 +395,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'TestOverwrite' }).orFail();
-      expect(foundTracker.count).toEqual(2);
+      expect(foundTracker.count).toEqual(2n);
     });
 
     it('should use modelName if "overwriteModelName" is falsy', async () => {
@@ -387,7 +418,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-EOMN' }).orFail();
-      expect(foundTracker.count).toEqual(0);
+      expect(foundTracker.count).toEqual(0n);
     });
 
     it('should support "overwriteModelName" being a function', async () => {
@@ -424,7 +455,7 @@ describe('Basic Suite', () => {
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
       const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-OMNF-test' }).orFail();
-      expect(foundTracker.count).toEqual(0);
+      expect(foundTracker.count).toEqual(0n);
     });
 
     it('should throw a error if "overwriteModelName" is a function but returns a empty string', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -38,13 +38,13 @@ describe('Basic Suite', () => {
   });
 
   describe('AutoIncrementID', () => {
-    it('Basic Function Mongoose', async () => {
+    it('Basic Function Mongoose (Number)', async () => {
       const schema = new mongoose.Schema({
         _id: Number,
         somefield: Number,
       });
       schema.plugin(AutoIncrementID, {});
-      const model = mongoose.model('AutoIncrementID-SomeModel', schema);
+      const model = mongoose.model('AutoIncrementID-SomeModel-Number', schema);
 
       // test initial 0
       {
@@ -82,13 +82,13 @@ describe('Basic Suite', () => {
       const trackerModel = mongoose.connection.models['identitycounter'];
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
-      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeModel' }).orFail();
+      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeModel-Number' }).orFail();
       expect(foundTracker.count).toEqual(2);
     });
 
-    it('Basic Function Typegoose', async () => {
+    it('Basic Function Typegoose (Number)', async () => {
       @plugin(AutoIncrementID, {})
-      @modelOptions({ options: { customName: 'AutoIncrementID-SomeClass' } })
+      @modelOptions({ options: { customName: 'AutoIncrementID-SomeClass-Number' } })
       class SomeClass {
         @prop()
         public _id?: number;
@@ -135,7 +135,108 @@ describe('Basic Suite', () => {
       const trackerModel = mongoose.connection.models['identitycounter'];
       expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
 
-      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeClass' }).orFail();
+      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeClass-Number' }).orFail();
+      expect(foundTracker.count).toEqual(2);
+    });
+
+    it('Basic Function Mongoose (BigInt)', async () => {
+      const schema = new mongoose.Schema({
+        _id: BigInt,
+        somefield: Number,
+      });
+      schema.plugin(AutoIncrementID, {});
+      const model = mongoose.model('AutoIncrementID-SomeModel-BigInt', schema);
+
+      // test initial 0
+      {
+        const doc = await model.create({ somefield: 10 });
+        expect(doc.somefield).toBe(10);
+        expect(doc._id).toBe(0n);
+
+        await doc.save();
+        expect(doc.somefield).toBe(10);
+        expect(doc._id).toBe(0n);
+      }
+
+      // test add 1
+      {
+        const doc = await model.create({ somefield: 20 });
+        expect(doc.somefield).toBe(20);
+        expect(doc._id).toBe(1n);
+
+        await doc.save();
+        expect(doc.somefield).toBe(20);
+        expect(doc._id).toBe(1n);
+      }
+
+      // test add another 1
+      {
+        const doc = await model.create({ somefield: 30 });
+        expect(doc.somefield).toBe(30);
+        expect(doc._id).toBe(2n);
+
+        await doc.save();
+        expect(doc.somefield).toBe(30);
+        expect(doc._id).toBe(2n);
+      }
+
+      const trackerModel = mongoose.connection.models['identitycounter'];
+      expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
+
+      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeModel-BigInt' }).orFail();
+      expect(foundTracker.count).toEqual(2);
+    });
+
+    it('Basic Function Typegoose (BigInt)', async () => {
+      @plugin(AutoIncrementID, {})
+      @modelOptions({ options: { customName: 'AutoIncrementID-SomeClass-BigInt' } })
+      class SomeClass {
+        @prop()
+        public _id?: bigint;
+
+        @prop({ required: true })
+        public someIncrementedField!: number;
+      }
+
+      const SomeModel = getModelForClass(SomeClass);
+
+      // test initial 0
+      {
+        const doc = await SomeModel.create({ someIncrementedField: 10 });
+        expect(doc.someIncrementedField).toBe(10);
+        expect(doc._id).toBe(0n);
+
+        await doc.save();
+        expect(doc.someIncrementedField).toBe(10);
+        expect(doc._id).toBe(0n);
+      }
+
+      // test add 1
+      {
+        const doc = await SomeModel.create({ someIncrementedField: 20 });
+        expect(doc.someIncrementedField).toBe(20);
+        expect(doc._id).toBe(1n);
+
+        await doc.save();
+        expect(doc.someIncrementedField).toBe(20);
+        expect(doc._id).toBe(1n);
+      }
+
+      // test add another 1
+      {
+        const doc = await SomeModel.create({ someIncrementedField: 30 });
+        expect(doc.someIncrementedField).toBe(30);
+        expect(doc._id).toBe(2n);
+
+        await doc.save();
+        expect(doc.someIncrementedField).toBe(30);
+        expect(doc._id).toBe(2n);
+      }
+
+      const trackerModel = mongoose.connection.models['identitycounter'];
+      expect(Object.getPrototypeOf(trackerModel)).toStrictEqual(mongoose.Model);
+
+      const foundTracker = await trackerModel.findOne({ modelName: 'AutoIncrementID-SomeClass-BigInt' }).orFail();
       expect(foundTracker.count).toEqual(2);
     });
 


### PR DESCRIPTION
Mongoose supports BigInts as a schema field type, and this library already works with them as-is. The only thing preventing this was a check for only `Number` of the field type