### PR TITLE
Upgrade to mongoose 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ I started `@typegoose/auto-increment` because `mongoose-auto-increment` and `mon
 
 - Node 14.17.0+
 - TypeScript 4.9+ (older versions could work, but are not tested)
-- mongoose 7.5.0+
+- mongoose 8.0.0+
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "contributors": [],
   "license": "MIT",
   "peerDependencies": {
-    "mongoose": "~7.6.1"
+    "mongoose": "~8.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.2",
@@ -54,7 +54,7 @@
     "jest": "^29.7.0",
     "lint-staged": "^13.2.3",
     "mongodb-memory-server": "^9.0.0",
-    "mongoose": "~7.6.1",
+    "mongoose": "~8.0.0",
     "prettier": "^3.0.3",
     "rimraf": "5.0.5",
     "semantic-release": "^19.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,11 @@ bson@^5.5.0:
   resolved "https://registry.yarnpkg.com/bson/-/bson-5.5.0.tgz#a419cc69f368d2def3b8b22ea03ed1c9be40e53f"
   integrity sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==
 
+bson@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-6.2.0.tgz#4b6acafc266ba18eeee111373c2699304a9ba0a3"
+  integrity sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -5221,7 +5226,16 @@ mongodb-memory-server@^9.0.0:
     mongodb-memory-server-core "9.0.0"
     tslib "^2.6.2"
 
-mongodb@5.9.0, mongodb@^5.9.0:
+mongodb@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.2.0.tgz#2c9dcb3eeaf528ed850e94b3df392de6c6b0d7ab"
+  integrity sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.1.0"
+    bson "^6.2.0"
+    mongodb-connection-string-url "^2.6.0"
+
+mongodb@^5.9.0:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.9.0.tgz#5a22065fa8cfaf1d58bf2e3c451cd2c4bfa983a2"
   integrity sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==
@@ -5232,14 +5246,14 @@ mongodb@5.9.0, mongodb@^5.9.0:
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
 
-mongoose@~7.6.1:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.6.1.tgz#39e4d25af26d0399468d4c0ac7373c4a8a838e3e"
-  integrity sha512-Iflr60FL7mabBdgAtumLTwEGdZGV6IKHfF7F75En2JWpPitorwQeCFqWPcPHRnBxncKANl3gwI9nh2Yb4y3/sA==
+mongoose@~8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.0.0.tgz#f14175eebfaf5256855d7cbd58bf862819b3fd12"
+  integrity sha512-PzwkLgm1Jhj0NQdgGfnFsu0QP9V1sBFgbavEgh/IPAUzKAagzvEhuaBuAQOQGjczVWnpIU9tBqyd02cOTgsPlA==
   dependencies:
-    bson "^5.5.0"
+    bson "^6.2.0"
     kareem "2.5.1"
-    mongodb "5.9.0"
+    mongodb "6.2.0"
     mpath "0.9.0"
     mquery "5.0.0"
     ms "2.1.3"


### PR DESCRIPTION
Update mongoose to 8.0.0 - no breaking changes affect this plugin. Attempted to update Typegoose, but looks like that'll require a maintainer to look into test failures.

We aim to use this without typegoose, and have already updated to mongoose 8, so having this plugin available asap would be helpful.
